### PR TITLE
Do not error on non-included docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(
         canonical = "https://juliaastro.org/Astroalign/stable/",
     ),
     plugins = [links],
+    warnonly = [:missing_docs]
 )
 
 deploydocs(;


### PR DESCRIPTION
This option makes it so that documenter.jl will only print a warning if functions with docstrings are not included in the documentation. Required for #21 which adds functions with docstrings that are not exported.