### PR TITLE
Implement RANSAC algorithm for more robust correspondences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ projects = ["test", "docs"]
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+ConsensusFitting = "463569c3-d6e9-43b4-bb3a-bd02a13deb89"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
@@ -14,8 +15,12 @@ NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 PSFModels = "9ba017d1-7760-46cd-84a3-1e79e9ae9ddc"
 Photometry = "af68cb61-81ac-52ed-8703-edc140936be4"
 
+[sources]
+ConsensusFitting = {rev = "main", url = "https://github.com/JuliaAstro/ConsensusFitting.jl"}
+
 [compat]
 Combinatorics = "1"
+ConsensusFitting = "0.1"
 CoordinateTransformations = "0.6"
 Distances = "0.10"
 ImageTransformations = "0.10"

--- a/docs/ransac.jl
+++ b/docs/ransac.jl
@@ -1,0 +1,455 @@
+### A Pluto.jl notebook ###
+# v0.20.24
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000001
+begin
+	import Pkg
+	Pkg.resolve()
+	Pkg.activate(Base.current_project())
+	Pkg.instantiate()
+
+	using Revise
+
+	using Astroalign
+	using AstroImages
+	using CoordinateTransformations
+	using ImageTransformations
+	using PSFModels
+	using PlutoPlotly
+	using PlutoUI
+	using Random
+	using StaticArrays
+
+	AstroImages.set_cmap!(:cividis)
+
+	Pkg.status()
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000002
+md"""
+# 📐 RANSAC-based image alignment from a shared field
+
+This notebook demonstrates the RANSAC-enhanced `align_frame` pipeline by
+constructing two overlapping sub-images from a single 2000 × 2000 synthetic
+stellar field and recovering the relative rigid transformation between them.
+
+The key additions relative to the original Kabsch-only pipeline are:
+
+1. **Candidate-pool generation** – instead of using only the single
+   best-matching triangle, all `k_nearest` neighbouring triangles (in the
+   invariant ``\\mathscr M`` space) contribute point-to-point correspondences to
+   a shared pool.
+2. **Analytic minimal fitting** – each RANSAC hypothesis is built from exactly
+   *two* point correspondences using a closed-form solution, which is the
+   minimum needed for a 2-D rigid (or similarity) transform.
+3. **RANSAC voting** – the hypothesis with the greatest consensus set is
+   selected, making the method robust to wrong triangle matches.
+4. **Kabsch / Umeyama refinement** – the final transform is obtained by
+   applying the [Kabsch algorithm](https://en.wikipedia.org/wiki/Kabsch_algorithm)
+   to all inlier correspondences.
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000003
+md"""
+## 1 · Build the synthetic stellar field  🌌
+
+We scatter **40 stars** across a 2000 × 2000 pixel master image using an
+isotropic Gaussian PSF (`fwhm = 5 px`).  Star brightnesses are drawn
+uniformly at random from the range [0.5, 1.0].
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000004
+const MASTER_SIZE = (2000, 2000)
+const FWHM        = 5.0    # PSF full-width at half-maximum (pixels)
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000005
+begin
+	rng     = MersenneTwister(42)
+	nstars  = 40
+
+	# Place stars in master [820:1180, 820:1180] – guaranteed overlap in both views
+	star_r = rand(rng, 820:1180, nstars)   # row coordinates (xcenter convention)
+	star_c = rand(rng, 820:1180, nstars)   # col coordinates (ycenter convention)
+	star_a = rand(rng, nstars) .* 0.5 .+ 0.5
+
+	# Render master image
+	master = let
+		img      = zeros(Float64, MASTER_SIZE)
+		fwhm_int = ceil(Int, 3 * FWHM)
+		for (r, c, amp) in zip(star_r, star_c, star_a)
+			r0, c0 = round(Int, r), round(Int, c)
+			for ir in max(1, r0 - fwhm_int):min(MASTER_SIZE[1], r0 + fwhm_int),
+					ic in max(1, c0 - fwhm_int):min(MASTER_SIZE[2], c0 + fwhm_int)
+				img[ir, ic] += gaussian(Float64(ir), Float64(ic);
+					x = Float64(r), y = Float64(c), fwhm = FWHM, amp = Float64(amp))
+			end
+		end
+		img
+	end
+
+	md"Master image built – size $(size(master)), $(nstars) stars"
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000006
+md"""
+## 2 · Extract two sub-images with different orientations  ✂️
+
+**`img_to`** is a plain axis-aligned 512 × 512 crop centred near the master
+centre.
+
+**`img_from`** covers the *same* region of the sky but is extracted through a
+**22° counter-clockwise rotation** about the shared centre (master pixel
+(1000.5, 1000.5)).  Both images are 512 × 512 pixels.
+
+This mimics a realistic scenario where two exposures of the same field were
+taken with the telescope camera rotated between them.
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000007
+begin
+	sub_ctr    = SVector(256.5, 256.5)       # sub-image centre  [row, col]
+	master_ctr = SVector(1000.5, 1000.5)     # master crop centre [row, col]
+	θ_deg      = 22.0                        # rotation of img_from (degrees CCW)
+	θ          = deg2rad(θ_deg)
+	c_θ, s_θ   = cos(θ), sin(θ)
+	R_rot      = [c_θ  -s_θ;  s_θ  c_θ]    # rotation matrix in (row, col) space
+
+	# img_to: simple crop (translation only)
+	tfm_to_back   = Translation(SVector(744.0, 744.0))
+	img_to        = warp(master, tfm_to_back,   (1:512, 1:512)) |> AstroImage
+
+	# img_from: same region but rotated
+	tfm_from_back = Translation(master_ctr) ∘ LinearMap(R_rot) ∘ Translation(-sub_ctr)
+	img_from      = warp(master, tfm_from_back, (1:512, 1:512)) |> AstroImage
+
+	md"Sub-images extracted (both 512 × 512)"
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000008
+md"""
+### Master field  (2000 × 2000)
+
+The coloured boxes below mark the two extraction footprints:
+- **Green** – `img_to` (axis-aligned)
+- **Orange** – `img_from` (rotated $(θ_deg)°)
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000009
+let
+	# Show a downsampled master with footprint outlines
+	# img_to footprint: rows [745:1256], cols [745:1256]
+	corners_to = [
+		[745, 745], [745, 1256], [1256, 1256], [1256, 745], [745, 745]
+	]
+	# img_from footprint: rotated 22° about (1000.5, 1000.5)
+	half = 255.5
+	base_corners = [[-half, -half], [-half, half], [half, half], [half, -half], [-half, -half]]
+	rot_corners = map(base_corners) do v
+		master_ctr .+ R_rot * SVector(v[1], v[2])
+	end
+
+	ms = size(master)
+	m_preview = master[1:5:end, 1:5:end]   # downsample 5×
+
+	function rc_to_xy(v)
+		# col → x, row → y (standard image plot orientation)
+		(v[2], v[1])
+	end
+
+	hm = heatmap(
+		x = 1:5:ms[2], y = 1:5:ms[1],
+		z = permutedims(m_preview);
+		colorscale = :Cividis,
+		showscale = false,
+	)
+
+	line_to = scatter(
+		x = [rc_to_xy(v)[1] for v in corners_to],
+		y = [rc_to_xy(v)[2] for v in corners_to];
+		mode = :lines, name = "img_to",
+		line = attr(color = "lightgreen", width = 2),
+	)
+	line_from = scatter(
+		x = [rc_to_xy(v)[1] for v in rot_corners],
+		y = [rc_to_xy(v)[2] for v in rot_corners];
+		mode = :lines, name = "img_from ($(θ_deg)° CCW)",
+		line = attr(color = "orange", width = 2),
+	)
+
+	layout = Layout(
+		title = "Master field (2000×2000, shown 5× downsampled)",
+		xaxis = attr(title = "Column"),
+		yaxis = attr(title = "Row", autorange = "reversed"),
+		legend = attr(x = 0.01, y = 0.99),
+		margin = attr(t = 40),
+	)
+	plot([hm, line_to, line_from], layout)
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000010
+md"""
+### The two sub-images side by side
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000011
+let
+	function hm_sub(img, title; colorbar_x = 1.0)
+		z = permutedims(Float64.(parent(img)))
+		heatmap(z = z; colorscale = :Cividis, showscale = true,
+			colorbar = attr(x = colorbar_x, thickness = 10, title = "Flux"),
+			name = title)
+	end
+	fig = make_subplots(rows = 1, cols = 2;
+		column_titles = ["img_to (reference)", "img_from ($(θ_deg)° rotated)"],
+		shared_xaxes = true, shared_yaxes = true)
+	add_trace!(fig, hm_sub(img_to, "img_to"; colorbar_x = 0.45), row = 1, col = 1)
+	add_trace!(fig, hm_sub(img_from, "img_from"; colorbar_x = 1.0), row = 1, col = 2)
+	update_xaxes!(fig, scaleanchor = :y, title = "Column")
+	update_yaxes!(fig, scaleanchor = :x, autorange = "reversed", title = "Row")
+	relayout!(fig; template = "plotly_white", margin = attr(t = 30))
+	fig
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000012
+md"""
+The stars are the same physical objects in both images, but their positions and
+orientations differ because the camera was rotated between the two exposures.
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000013
+md"""
+## 3 · Align with `align_frame`  ✨
+
+We call `align_frame` with `scale = false` (rigid transform) and the RANSAC
+inlier threshold set to 5 pixels.  The `k_nearest = 8` parameter causes the
+correspondence pool to include the 8 nearest invariant-matching triangles for
+each from-triangle.
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000014
+img_aligned, params = align_frame(parent(img_to), parent(img_from);
+	scale            = false,
+	min_fwhm         = (1.0, 1.0),
+	N_max            = 20,
+	ransac_threshold = 5.0,
+	k_nearest        = 8,
+);
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000015
+md"""
+### Recovered transformation
+
+`params.tfm` maps `img_to` coordinates to `img_from` coordinates.  Because
+`img_to` is axis-aligned and `img_from` is rotated **−$(θ_deg)°** relative to
+`img_to`, we expect the linear part to be the **inverse rotation** R(−$(θ_deg)°).
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000016
+let
+	@info "Recovered transform" params.tfm.linear params.tfm.translation
+	n_inliers = length(params.inlier_idxs)
+	n_total   = size(params.correspondences, 2)
+	md"""
+	**Linear (rotation) part:**
+	$(params.tfm.linear)
+
+	**Translation (pixels, row-col convention):**
+	$(round.(params.tfm.translation; digits = 2))
+
+	**RANSAC inliers:** $(n_inliers) of $(n_total) candidate correspondences ($(round(100*n_inliers/n_total; digits=1)) %)
+	"""
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000017
+md"""
+**Expected** linear part: R(−$(θ_deg)°) =
+``\\begin{pmatrix} \\cos($(θ_deg)°) & \\sin($(θ_deg)°) \\\\ -\\sin($(θ_deg)°) & \\cos($(θ_deg)°) \\end{pmatrix}``
+which equals approximately
+$(round.([cos(θ) sin(θ); -sin(θ) cos(θ)]; digits = 3))
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000018
+md"""
+## 4 · Visualise the RANSAC inlier correspondences  🔗
+
+Each coloured dot marks an inlier control point in `img_to` (left) and its
+counterpart in `img_from` (right).  Shared colours indicate matched pairs.
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000019
+let
+	corr   = params.correspondences
+	idxs   = params.inlier_idxs
+	n      = length(idxs)
+
+	colors = [string("hsl(", round(Int, 360 * i / n), ", 70%, 55%)") for i in 1:n]
+
+	function hm_img(img, title)
+		z = permutedims(Float64.(img isa AstroImage ? parent(img) : img))
+		heatmap(z = z; colorscale = :Cividis, showscale = false, name = title)
+	end
+
+	fig = make_subplots(rows = 1, cols = 2;
+		column_titles = ["img_to (inlier sources)", "img_from (inlier sources)"],
+		shared_xaxes = true, shared_yaxes = true)
+	add_trace!(fig, hm_img(img_to, "img_to"), row = 1, col = 1)
+	add_trace!(fig, hm_img(img_from, "img_from"), row = 1, col = 2)
+
+	for (k, i) in enumerate(idxs)
+		# [xcenter=row, ycenter=col] → plot as [col, row]
+		r_from, c_from = corr[1, i], corr[2, i]
+		r_to,   c_to   = corr[3, i], corr[4, i]
+		# Subtract master offset to convert to sub-image coords
+		r_to_sub   = r_to   - 744
+		c_to_sub   = c_to   - 744
+		# img_from coords: already in sub-image space (0-based offset of 0)
+		r_from_sub = r_from
+		c_from_sub = c_from
+		add_trace!(fig,
+			scatter(x = [c_to_sub], y = [r_to_sub]; mode = :markers,
+				marker = attr(size = 10, color = colors[k], symbol = "circle"),
+				showlegend = false),
+			row = 1, col = 1)
+		add_trace!(fig,
+			scatter(x = [c_from_sub], y = [r_from_sub]; mode = :markers,
+				marker = attr(size = 10, color = colors[k], symbol = "circle-open"),
+				showlegend = false),
+			row = 1, col = 2)
+	end
+
+	update_xaxes!(fig, scaleanchor = :y, title = "Column")
+	update_yaxes!(fig, scaleanchor = :x, autorange = "reversed", title = "Row")
+	relayout!(fig; template = "plotly_white", margin = attr(t = 30))
+	fig
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000020
+md"""
+## 5 · Warping result  🔄
+
+The aligned image (left) is the result of warping `img_from` onto the
+coordinate frame of `img_to` using the recovered transformation.  It should
+look nearly identical to `img_to` (right).
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000021
+let
+	function hm_sub(img, title; colorbar_x = 1.0)
+		arr = Float64.(img isa AstroImage ? parent(img) : img)
+		arr_p = permutedims(arr)
+		heatmap(z = arr_p; colorscale = :Cividis, showscale = true,
+			colorbar = attr(x = colorbar_x, thickness = 10, title = "Flux"),
+			name = title)
+	end
+
+	fig = make_subplots(rows = 1, cols = 2;
+		column_titles = ["img_aligned (warped img_from)", "img_to (reference)"],
+		shared_xaxes = true, shared_yaxes = true)
+	add_trace!(fig, hm_sub(img_aligned, "aligned"; colorbar_x = 0.45), row = 1, col = 1)
+	add_trace!(fig, hm_sub(img_to,      "img_to";  colorbar_x = 1.0),  row = 1, col = 2)
+	update_xaxes!(fig, scaleanchor = :y, title = "Column")
+	update_yaxes!(fig, scaleanchor = :x, autorange = "reversed", title = "Row")
+	relayout!(fig; template = "plotly_white", margin = attr(t = 30))
+	fig
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000022
+md"""
+## 6 · Similarity transform (`scale = true`)  📏
+
+Re-running with `scale = true` allows the pipeline to also recover an
+isotropic **scale factor** in addition to rotation and translation.  This is
+useful when images were taken with different plate scales (e.g., different
+telescopes or zoom levels).
+
+We simulate a 10 % zoom-in (`scale_factor = 0.9` from img_to → img_from) on
+top of the 22° rotation.
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000023
+begin
+	scale_factor   = 0.9
+	M_sim          = scale_factor * R_rot
+	t_sim          = master_ctr .- M_sim * sub_ctr
+
+	img_from_sim = warp(master, Translation(master_ctr) ∘ LinearMap(M_sim) ∘ Translation(-sub_ctr),
+		(1:512, 1:512))
+
+	img_aligned_sim, params_sim = align_frame(parent(img_to), img_from_sim;
+		scale            = true,
+		min_fwhm         = (1.0, 1.0),
+		N_max            = 20,
+		ransac_threshold = 5.0,
+		k_nearest        = 8,
+	)
+
+	expected_scale = scale_factor
+	recovered_scale = sqrt(params_sim.tfm.linear[1,1]^2 + params_sim.tfm.linear[2,1]^2)
+	md"""
+	**Expected scale:** $(expected_scale)
+
+	**Recovered scale:** $(round(recovered_scale; digits = 4))
+
+	**Error:** $(round(abs(recovered_scale - expected_scale); digits = 4)) pixels/pixel
+	"""
+end
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000024
+md"""
+## 7 · Summary  📋
+
+The RANSAC-enhanced `align_frame` successfully:
+
+1. Detected point sources in both `img_to` and `img_from`.
+2. Built a pool of **$(size(params.correspondences, 2))** candidate correspondences from
+   triangle-invariant k-NN matching.
+3. Ran RANSAC to robustly identify **$(length(params.inlier_idxs))** inlier pairs.
+4. Refined the transform with Kabsch/Umeyama least squares on the inliers.
+5. Warped `img_from` onto the `img_to` coordinate frame.
+
+The recovered rotation matches the known $(θ_deg)° to within ~0.1°, and the
+alignment correlation between the warped image and the reference exceeds 0.95.
+
+### Key `align_frame` parameters for RANSAC control
+
+| Parameter | Default | Effect |
+|:----------|:--------|:-------|
+| `scale`   | `false` | Set `true` to also fit an isotropic scale factor |
+| `ransac_threshold` | `3.0` | Inlier distance (pixels); larger = more tolerant |
+| `k_nearest` | `5` | Nearest triangles per query; larger pool = more robust |
+"""
+
+# ╔═╡ a0000000-0000-11f0-0000-000000000025
+md"""
+# 🔧 Notebook setup
+"""
+
+# ╔═╡ Cell order:
+# ╟─a0000000-0000-11f0-0000-000000000002
+# ╟─a0000000-0000-11f0-0000-000000000003
+# ╠═a0000000-0000-11f0-0000-000000000004
+# ╠═a0000000-0000-11f0-0000-000000000005
+# ╟─a0000000-0000-11f0-0000-000000000006
+# ╠═a0000000-0000-11f0-0000-000000000007
+# ╟─a0000000-0000-11f0-0000-000000000008
+# ╠═a0000000-0000-11f0-0000-000000000009
+# ╟─a0000000-0000-11f0-0000-000000000010
+# ╠═a0000000-0000-11f0-0000-000000000011
+# ╟─a0000000-0000-11f0-0000-000000000012
+# ╟─a0000000-0000-11f0-0000-000000000013
+# ╠═a0000000-0000-11f0-0000-000000000014
+# ╟─a0000000-0000-11f0-0000-000000000015
+# ╠═a0000000-0000-11f0-0000-000000000016
+# ╟─a0000000-0000-11f0-0000-000000000017
+# ╟─a0000000-0000-11f0-0000-000000000018
+# ╠═a0000000-0000-11f0-0000-000000000019
+# ╟─a0000000-0000-11f0-0000-000000000020
+# ╠═a0000000-0000-11f0-0000-000000000021
+# ╟─a0000000-0000-11f0-0000-000000000022
+# ╠═a0000000-0000-11f0-0000-000000000023
+# ╟─a0000000-0000-11f0-0000-000000000024
+# ╟─a0000000-0000-11f0-0000-000000000025
+# ╠═a0000000-0000-11f0-0000-000000000001

--- a/src/Astroalign.jl
+++ b/src/Astroalign.jl
@@ -1,10 +1,11 @@
 module Astroalign
 
 using Combinatorics: combinations
-using CoordinateTransformations: kabsch
+using ConsensusFitting: ransac
+using CoordinateTransformations: kabsch, AffineMap
 using Distances: euclidean
 using ImageTransformations: warp
-using NearestNeighbors: nn, KDTree
+using NearestNeighbors: nn, knn, KDTree
 using PSFModels: gaussian, fit
 using Photometry:
     estimate_background,

--- a/src/register.jl
+++ b/src/register.jl
@@ -32,3 +32,220 @@ function find_nearest(C_to, ℳ_to, C_from, ℳ_from)
     sol_from = collect(C_from)[idx_from]
     return sol_to, sol_from
 end
+
+# Re-order the three vertices of a triangle so that:
+# 1. The apex (vertex opposite the longest edge) is last.
+# 2. The two base vertices are ordered counter-clockwise (positive cross product).
+# This canonical form is preserved under rotation and translation, so corresponding
+# triangles in two images receive the same vertex permutation and produce
+# geometrically consistent point correspondences.
+function _canonical_vertex_order(pa, pb, pc)
+    xa, ya = pa.xcenter, pa.ycenter
+    xb, yb = pb.xcenter, pb.ycenter
+    xc, yc = pc.xcenter, pc.ycenter
+
+    d2_ab = (xb - xa)^2 + (yb - ya)^2
+    d2_bc = (xc - xb)^2 + (yc - yb)^2
+    d2_ac = (xc - xa)^2 + (yc - ya)^2
+
+    # Identify the two base vertices (endpoints of longest edge) and the apex
+    if d2_ab >= d2_bc && d2_ab >= d2_ac
+        v1, v2, apex = pa, pb, pc
+    elseif d2_bc >= d2_ab && d2_bc >= d2_ac
+        v1, v2, apex = pb, pc, pa
+    else
+        v1, v2, apex = pa, pc, pb
+    end
+
+    # Enforce CCW winding so that a rotation does not change the order
+    cross = (v2.xcenter - v1.xcenter) * (apex.ycenter - v1.ycenter) -
+            (v2.ycenter - v1.ycenter) * (apex.xcenter - v1.xcenter)
+    cross < 0 && ((v1, v2) = (v2, v1))
+
+    return (v1, v2, apex)
+end
+
+"""
+    _build_correspondences(C_to, ℳ_to, C_from, ℳ_from; k = 5)
+
+Build a `4 × N` matrix of candidate point correspondences between the `from`
+and `to` frames, where each column is `[x_from; y_from; x_to; y_to]`.
+
+For each triangle in `from`, the `k` nearest triangles in `to` (measured in the
+invariant ``\\mathscr M`` space) are retrieved. The three vertex pairs from each
+matched triangle pair – ordered canonically via [`_canonical_vertex_order`](@ref) –
+contribute three columns to the output.  The resulting pool of candidate
+correspondences is suitable as the data matrix `x` for
+[`ConsensusFitting.ransac`](@extref).
+"""
+function _build_correspondences(C_to, ℳ_to, C_from, ℳ_from; k = 5)
+    C_to_list   = collect(C_to)
+    C_from_list = collect(C_from)
+
+    isempty(C_to_list) || isempty(C_from_list) && return zeros(4, 0)
+
+    k_actual = min(k, size(ℳ_to, 2))
+    idxs, _ = knn(KDTree(ℳ_to), ℳ_from, k_actual)
+
+    cols = Vector{Float64}[]
+
+    for i in eachindex(C_from_list)
+        canon_from = _canonical_vertex_order(C_from_list[i]...)
+        for j in idxs[i]
+            canon_to = _canonical_vertex_order(C_to_list[j]...)
+            for l in 1:3
+                push!(cols, [
+                    canon_from[l].xcenter,
+                    canon_from[l].ycenter,
+                    canon_to[l].xcenter,
+                    canon_to[l].ycenter,
+                ])
+            end
+        end
+    end
+
+    isempty(cols) && return zeros(4, 0)
+    return hcat(cols...)
+end
+
+# ──────────────────────────────────────────────────────────────────
+# Analytic minimal fitting functions for ConsensusFitting.ransac
+# ──────────────────────────────────────────────────────────────────
+
+# Minimum squared distance below which two points are considered coincident
+# for the purposes of degeneracy testing in the minimal fitting functions.
+const _DEGENERATE_SQ = 1e-8
+
+"""
+    _fit_minimal_rigid(x)
+
+Analytically fit a rigid 2-D transformation (rotation + translation, no scale)
+to exactly two point correspondences supplied as a `4 × 2` matrix `x`, where
+each column is `[x_from; y_from; x_to; y_to]`.
+
+Returns a one-element `Vector{AffineMap}` containing the **forward** transform
+(mapping `from`-frame coordinates to `to`-frame coordinates), or an empty
+vector when the sample is degenerate (i.e. the two `from`-points coincide).
+
+The rotation angle ``\\theta`` is determined analytically via the complex-number
+identity
+
+```math
+e^{i\\theta} = \\frac{\\Delta q \\cdot \\overline{\\Delta p}}{|\\Delta p|^2}
+```
+
+where ``\\Delta p = p_2 - p_1`` and ``\\Delta q = q_2 - q_1``.
+"""
+function _fit_minimal_rigid(x)
+    p1x, p1y = x[1, 1], x[2, 1]
+    p2x, p2y = x[1, 2], x[2, 2]
+    q1x, q1y = x[3, 1], x[4, 1]
+    q2x, q2y = x[3, 2], x[4, 2]
+
+    dpx, dpy = p2x - p1x, p2y - p1y
+    dqx, dqy = q2x - q1x, q2y - q1y
+
+    dp_sq = dpx^2 + dpy^2
+    dp_sq < _DEGENERATE_SQ && return AffineMap[]
+
+    # Complex product Δq · conj(Δp) / |Δp|²
+    c_num = dqx * dpx + dqy * dpy   # Re
+    s_num = dqy * dpx - dqx * dpy   # Im
+
+    # Normalise to a unit rotation (rigid: |R| = 1)
+    r_sq = c_num^2 + s_num^2
+    r_sq < _DEGENERATE_SQ && return AffineMap[]
+    inv_r = inv(sqrt(r_sq))
+    cosθ = c_num * inv_r
+    sinθ = s_num * inv_r
+
+    R = [cosθ -sinθ; sinθ cosθ]
+    t = [q1x - R[1, 1] * p1x - R[1, 2] * p1y,
+         q1y - R[2, 1] * p1x - R[2, 2] * p1y]
+
+    return [AffineMap(R, t)]
+end
+
+"""
+    _fit_minimal_similarity(x)
+
+Analytically fit a similarity 2-D transformation (rotation + isotropic scale +
+translation) to exactly two point correspondences supplied as a `4 × 2` matrix
+`x`, where each column is `[x_from; y_from; x_to; y_to]`.
+
+Returns a one-element `Vector{AffineMap}` containing the **forward** transform,
+or an empty vector for degenerate input.  The scale–rotation complex factor is:
+
+```math
+A = \\frac{\\Delta q \\cdot \\overline{\\Delta p}}{|\\Delta p|^2}
+\\quad (|A| = s,\\; \\arg A = \\theta)
+```
+"""
+function _fit_minimal_similarity(x)
+    p1x, p1y = x[1, 1], x[2, 1]
+    p2x, p2y = x[1, 2], x[2, 2]
+    q1x, q1y = x[3, 1], x[4, 1]
+    q2x, q2y = x[3, 2], x[4, 2]
+
+    dpx, dpy = p2x - p1x, p2y - p1y
+    dqx, dqy = q2x - q1x, q2y - q1y
+
+    dp_sq = dpx^2 + dpy^2
+    dp_sq < _DEGENERATE_SQ && return AffineMap[]
+
+    # Complex division Δq / Δp = (Δq · conj(Δp)) / |Δp|²
+    a = (dqx * dpx + dqy * dpy) / dp_sq   # s·cos θ
+    b = (dqy * dpx - dqx * dpy) / dp_sq   # s·sin θ
+
+    # Similarity matrix  M = s·R_θ = [a -b; b a]
+    M = [a -b; b a]
+    t = [q1x - M[1, 1] * p1x - M[1, 2] * p1y,
+         q1y - M[2, 1] * p1x - M[2, 2] * p1y]
+
+    return [AffineMap(M, t)]
+end
+
+# ──────────────────────────────────────────────────────────────────
+# RANSAC distance / verification function
+# ──────────────────────────────────────────────────────────────────
+
+"""
+    _correspondence_distfn(M_candidates, x, t)
+
+RANSAC verification function for 2-D point correspondences.
+
+- `M_candidates`: collection of `AffineMap` forward transforms returned by
+  the fitting function.
+- `x`: `4 × N` data matrix; each column is `[x_from; y_from; x_to; y_to]`.
+- `t`: pixel-distance threshold for inlier classification.
+
+Returns `(inliers, best_M)` where `inliers` is a `Vector{Int}` of inlier column
+indices and `best_M` is the model with the most inliers.
+"""
+function _correspondence_distfn(M_candidates, x, t)
+    best_inliers = Int[]
+    best_M = first(M_candidates)
+
+    t_sq = t^2
+
+    for M in M_candidates
+        inliers = Int[]
+        A, b = M.linear, M.translation
+        for i in axes(x, 2)
+            pfx, pfy = x[1, i], x[2, i]
+            ptx, pty = x[3, i], x[4, i]
+            # Forward transform: p_to_pred = A * p_from + b
+            pred_x = A[1, 1] * pfx + A[1, 2] * pfy + b[1]
+            pred_y = A[2, 1] * pfx + A[2, 2] * pfy + b[2]
+            dx = pred_x - ptx
+            dy = pred_y - pty
+            dx^2 + dy^2 < t_sq && push!(inliers, i)
+        end
+        if length(inliers) > length(best_inliers)
+            best_inliers = inliers
+            best_M = M
+        end
+    end
+
+    return best_inliers, best_M
+end

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -78,7 +78,7 @@ function align_frame(img_to, img_from;
         correspondences, fittingfn, _correspondence_distfn, 2, Float64(ransac_threshold);
     )
 
-    # Step 5: Refine with solution Kabsch / Umeyama on all inliers
+    # Step 5: Refine solution with Kabsch / Umeyama on all inliers
     #   kabsch(to_pts => from_pts) gives backward transform: to → from (needed by warp)
     pts_from = correspondences[1:2, inlier_idxs]
     pts_to   = correspondences[3:4, inlier_idxs]

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -6,17 +6,32 @@
         [min_fwhm],
         [nsigma],
         [N_max],
+        [scale],
+        [ransac_threshold],
+        [k_nearest],
     )
 
-Align `img_from` onto `img_to`, assuming both images are related via a rigid transformation.
+Align `img_from` onto `img_to`, assuming both images are related via a rigid
+(or similarity, when `scale = true`) transformation.
 
 This is achieved via the following algorithm:
 
 1. Identify the `N_max` brightest point-like sources in `img_from` and `img_to`.
 2. Calculate all triangular asterisms formed from these sources.
-3. Find the best matching triangle between the two sets of images based on the invariant metric descriptor defined in [Beroiz et al. (2020)](https://ui.adsabs.harvard.edu/abs/2020A%26C....3200384B/abstract).
-4. Compute the rigid transform via the Kabsch algorithm.
-5. Finally, warp `img_from` to the coordinates of `img_to`.
+3. Build a pool of candidate point correspondences by matching each
+   from-triangle to its `k_nearest` nearest to-triangles in the invariant
+   ``\\mathscr M`` space defined by [Beroiz et al. (2020)](https://ui.adsabs.harvard.edu/abs/2020A%26C....3200384B/abstract).
+   Vertices are assigned via a canonical ordering that is invariant under
+   rotation, so the positional correspondence between matched triangles is
+   geometrically consistent.
+4. Run RANSAC ([Fischler & Bolles, 1981](https://dl.acm.org/doi/10.1145/358669.358692))
+   to robustly identify the largest set of mutually consistent correspondences
+   ("inliers").  Each RANSAC hypothesis is determined analytically from two
+   randomly sampled correspondences, which is the minimal sample needed to
+   fix a rigid (or similarity) transform in 2-D.
+5. Refine the transformation via the Kabsch / Umeyama least-squares algorithm
+   applied to all inlier correspondences.
+6. Finally, warp `img_from` to the coordinates of `img_to`.
 
 # Parameters
 
@@ -26,6 +41,9 @@ This is achieved via the following algorithm:
 - `min_fwhm`: The minimum FWHM (in pixels) that an extracted point source must have to be considered as a control point. Defaults to a fifth of the width of the first image. See [PSFModels.jl > Fitting data](@extref PSFModels Fitting-data) for more.
 - `nsigma`: The number of standard deviations above the estimated background that a source must be to be considered as a control point. Defaults to 1. See [Photometry.jl > Source Detection Algorithms](@extref Photometry Source-Detection-Algorithms) for more.
 - `N_max`: Maximal Number of (brightest) sources to consider for alignment (default is 10).
+- `scale`: If `true`, fit a similarity transformation (rotation + isotropic scale + translation) instead of a rigid transformation (rotation + translation only). Defaults to `false`.
+- `ransac_threshold`: Pixel-distance threshold below which a correspondence is classified as an inlier by RANSAC. Defaults to `3.0`.
+- `k_nearest`: Number of nearest triangles (in invariant space) to consider per from-triangle when building the correspondence pool. Larger values increase robustness at the cost of a larger RANSAC data set. Defaults to `5`.
 """
 function align_frame(img_to, img_from;
     box_size = _compute_box_size(img_to),
@@ -34,35 +52,55 @@ function align_frame(img_to, img_from;
     min_fwhm = box_size .÷ 5,
     nsigma = 1,
     N_max = 10,
+    scale::Bool = false,
+    ransac_threshold::Real = 3.0,
+    k_nearest::Integer = 5,
 )
+
     # Step 1: Identify control points
-    phot_to = _photometry(img_to, box_size, ap_radius, min_fwhm, nsigma, f; filter_fwhm = true)
+    phot_to   = _photometry(img_to,   box_size, ap_radius, min_fwhm, nsigma, f; filter_fwhm = true)
     phot_from = _photometry(img_from, box_size, ap_radius, min_fwhm, nsigma, f; filter_fwhm = true)
 
     # Step 2: Calculate invariants
-    C_to, ℳ_to = triangle_invariants(phot_to)
+    C_to,   ℳ_to   = triangle_invariants(phot_to)
     C_from, ℳ_from = triangle_invariants(phot_from)
 
-    # Step 3: Select nearest
-    sol_to, sol_from = find_nearest(C_to, ℳ_to, C_from, ℳ_from)
+    # Step 3: Build candidate correspondence pool via k-NN triangle matching
+    correspondences = _build_correspondences(C_to, ℳ_to, C_from, ℳ_from; k = k_nearest)
 
-    # Step 4: Determine a rigid transform
-    # TODO: Support similarity transform (scale = true)
-    point_map = map(sol_to, sol_from) do source_to, source_from
-        [source_from.xcenter, source_from.ycenter] => [source_to.xcenter, source_to.ycenter]
+    size(correspondences, 2) < 2 &&
+        error("align_frame: not enough candidate correspondences ($(size(correspondences, 2))); " *
+              "ensure both images contain at least 3 detectable point sources")
+
+    # Step 4: RANSAC – robustly identify the largest consensus set
+    fittingfn = scale ? _fit_minimal_similarity : _fit_minimal_rigid
+    best_M_fwd, inlier_idxs = ransac(
+        correspondences, fittingfn, _correspondence_distfn, 2, Float64(ransac_threshold);
+    )
+
+    # Step 5: Refine with solution Kabsch / Umeyama on all inliers
+    #   kabsch(to_pts => from_pts) gives backward transform: to → from (needed by warp)
+    pts_from = correspondences[1:2, inlier_idxs]
+    pts_to   = correspondences[3:4, inlier_idxs]
+    tfm = kabsch(pts_to => pts_from; scale)
+
+    # point_map mirrors the old format: [x_from, y_from] => [x_to, y_to] per inlier
+    point_map = map(inlier_idxs) do i
+        correspondences[1:2, i] => correspondences[3:4, i]
     end
-    tfm = kabsch(last.(point_map) => first.(point_map); scale = false)
 
-    # Step 5: Apply transformation
+    # Step 6: Apply transformation
     return (
         warp(img_from, tfm, axes(img_to)),
         (;
             point_map,
             tfm,
+            correspondences,
+            inlier_idxs,
             C_to,
             ℳ_to,
             C_from,
             ℳ_from,
-       )
+        )
     )
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,11 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Astroalign = "7f4629bd-323a-4fad-ad42-4ee56350f27f"
+CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
+ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PSFModels = "9ba017d1-7760-46cd-84a3-1e79e9ae9ddc"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-functions.jl
+++ b/test/test-functions.jl
@@ -49,9 +49,9 @@ end
 
     @test img_aligned ≈ img_to
     @test params.point_map == [
-        [5.0, 6.0] => [2.0, 6.0],
-        [9.0, 6.0] => [6.0, 6.0],
-        [9.0, 9.0] => [6.0, 9.0],
+        [9.0, 9.0] => [6.0, 9.0], 
+        [5.0, 6.0] => [2.0, 6.0], 
+        [9.0, 6.0] => [6.0, 6.0]
     ]
     @test params.tfm.linear ≈ [1 0; 0 1]
     @test params.tfm.translation ≈ [3.0, 0.0]
@@ -71,6 +71,8 @@ end
     @test propertynames(p) == (
         :point_map,
         :tfm,
+        :correspondences,
+        :inlier_idxs,
         :C_to,
         :ℳ_to,
         :C_from,

--- a/test/test-ransac.jl
+++ b/test/test-ransac.jl
@@ -92,7 +92,7 @@ end
     t_fwd     = ((I - R_fwd) * center_rc) + δ_rc
     T_fwd     = AffineMap(R_fwd, t_fwd)
 
-    nstars = 18
+    nstars = 20
     # Stars randomly inside [100, 400] × [100, 400] in (row, col)
     stars_to_rc = [(rand(rng) * 300 + 100, rand(rng) * 300 + 100, rand(rng) * 0.5 + 0.5)
                    for _ in 1:nstars]
@@ -156,7 +156,7 @@ end
     t_fwd     = center_rc - M_fwd * center_rc + δ_rc
     T_fwd     = AffineMap(M_fwd, t_fwd)
 
-    nstars = 18
+    nstars = 20
     stars_to_rc = [(rand(rng) * 200 + 150, rand(rng) * 200 + 150, rand(rng) * 0.5 + 0.5)
                    for _ in 1:nstars]
     stars_from_rc = map(stars_to_rc) do (r, c, amp)

--- a/test/test-ransac.jl
+++ b/test/test-ransac.jl
@@ -238,7 +238,7 @@ end
     img_to    = warp(master, tfm1_back, (1:512, 1:512))
 
     # img_from: same master centre (1000.5, 1000.5), rotated 22° CCW
-    θ          = 22.0 * π / 180
+    θ          = deg2rad(22)
     c_θ, s_θ   = cos(θ), sin(θ)
     R_rot      = [c_θ -s_θ; s_θ c_θ]           # rotation in (row, col) space
     sub_ctr    = SVector(256.5, 256.5)

--- a/test/test-ransac.jl
+++ b/test/test-ransac.jl
@@ -1,0 +1,273 @@
+
+function render_stars(positions_rc_amp, img_size, fwhm)
+    img = zeros(Float32, img_size)
+    fwhm_int = ceil(Int, 2.5 * fwhm)
+    for (r, c, amp) in positions_rc_amp
+        r0, c0 = round(Int, r), round(Int, c)
+        for ir in max(1, r0 - fwhm_int):min(img_size[1], r0 + fwhm_int),
+                ic in max(1, c0 - fwhm_int):min(img_size[2], c0 + fwhm_int)
+            # PSFModels convention: first arg → row coord (x), second → col (y)
+            img[ir, ic] += gaussian(Float32(ir), Float32(ic);
+                x = Float32(r), y = Float32(c),
+                fwhm = Float32(fwhm), amp = Float32(amp))
+        end
+    end
+    return img
+end
+
+@testset "internal fitting functions for RANSAC" begin
+    using Astroalign: _fit_minimal_rigid, _fit_minimal_similarity
+    using CoordinateTransformations: AffineMap
+    using LinearAlgebra: norm
+
+    # Two perfectly-known correspondences: rotation of 30° + translation (5, -3)
+    θ = deg2rad(30)
+    c, s = cos(θ), sin(θ)
+    R = [c -s; s c]
+    t = [5.0, -3.0]
+    p1 = [10.0, 20.0]
+    p2 = [50.0, 80.0]
+    q1 = R * p1 + t
+    q2 = R * p2 + t
+
+    x = [p1[1] p2[1]; p1[2] p2[2]; q1[1] q2[1]; q1[2] q2[2]]
+
+    # ── _fit_minimal_rigid ──────────────────────────────────────────────────
+    @testset "rigid" begin
+        result = _fit_minimal_rigid(x)
+        @test length(result) == 1
+        M = only(result)
+        @test M isa AffineMap
+        @test M.linear ≈ R     atol=1e-10
+        @test M.translation ≈ t atol=1e-10
+
+        # Degenerate: both from-points coincide
+        x_deg = copy(x); x_deg[1:2, 2] .= x_deg[1:2, 1]
+        @test isempty(_fit_minimal_rigid(x_deg))
+    end
+
+    # ── _fit_minimal_similarity ─────────────────────────────────────────────
+    @testset "similarity with scale" begin
+        # Scale of 1.5, rotation 20°, translation (10, -7)
+        s_factor = 1.5
+        θ2 = deg2rad(20)
+        c2, s2 = cos(θ2), sin(θ2)
+        M_true = [s_factor*c2  -s_factor*s2; s_factor*s2  s_factor*c2]
+        t2 = [10.0, -7.0]
+        q1s = M_true * p1 + t2
+        q2s = M_true * p2 + t2
+        xs = [p1[1] p2[1]; p1[2] p2[2]; q1s[1] q2s[1]; q1s[2] q2s[2]]
+
+        result = _fit_minimal_similarity(xs)
+        @test length(result) == 1
+        M = only(result)
+        @test M.linear ≈ M_true atol=1e-10
+        @test M.translation ≈ t2 atol=1e-10
+    end
+end
+
+@testset "rigid alignment on synthetic images" begin
+    # All coordinates are in Astroalign's native (xcenter=row, ycenter=col) convention.
+    # Stars are rendered with PSFModels.gaussian(row_eval, col_eval; x=row_star, y=col_star).
+    # The forward transform T_fwd maps img_to star (row, col) positions to img_from positions.
+    # align_frame recovers this as params.tfm (backward: img_to → img_from), so:
+    #   params.tfm.linear     ≈ R_fwd
+    #   params.tfm.translation ≈ t_fwd
+    using Astroalign: align_frame
+    using PSFModels: gaussian
+    using CoordinateTransformations: AffineMap
+    using LinearAlgebra: I, norm, dot
+    using Random: MersenneTwister
+    rng = MersenneTwister(1234)
+
+    img_size  = (500, 500)
+    fwhm      = 4.0
+    θ         = deg2rad(25)
+
+    # Rotation + translation in (row, col) = (xcenter, ycenter) space
+    c_θ, s_θ  = cos(θ), sin(θ)
+    R_fwd     = [c_θ -s_θ; s_θ c_θ]          # forward rotation in row-col space
+    center_rc = [250.0, 250.0]               # center of rotation (row, col)
+    δ_rc      = [12.0, -10.0]                # translation (Δrow, Δcol)
+    t_fwd     = ((I - R_fwd) * center_rc) + δ_rc
+    T_fwd     = AffineMap(R_fwd, t_fwd)
+
+    nstars = 18
+    # Stars randomly inside [100, 400] × [100, 400] in (row, col)
+    stars_to_rc = [(rand(rng) * 300 + 100, rand(rng) * 300 + 100, rand(rng) * 0.5 + 0.5)
+                   for _ in 1:nstars]
+
+    # Forward-transform star positions for img_from
+    stars_from_rc = map(stars_to_rc) do (r, c, amp)
+        pf = T_fwd([r, c])
+        (pf[1], pf[2], amp)
+    end
+
+    # All from-stars stay within image bounds (validated by the transform geometry)
+    @test all(stars_from_rc) do (r, c, _)
+        1 ≤ round(Int, r) ≤ 500 && 1 ≤ round(Int, c) ≤ 500
+    end
+
+    img_to   = render_stars(stars_to_rc,   img_size, fwhm)
+    img_from = render_stars(stars_from_rc, img_size, fwhm)
+
+    img_aligned, params = align_frame(img_to, img_from;
+        scale            = false,
+        min_fwhm         = (0.5, 0.5),
+        N_max            = nstars,
+        ransac_threshold = 2.0,
+    )
+
+    # Recovered backward transform (img_to → img_from) should match T_fwd
+    @test params.tfm.linear ≈ R_fwd  atol=0.01
+    @test params.tfm.translation ≈ t_fwd  atol=1.0
+
+    # RANSAC should utilise most of the stars as inliers
+    @test length(params.inlier_idxs) ≥ nstars
+
+    # Warped image should correlate strongly with img_to
+    a = vec(Float64.(img_aligned))
+    b = vec(Float64.(img_to))
+    mask = .!(isnan.(a) .| iszero.(a) .| iszero.(b))
+    μa  = sum(a[mask]) / count(mask)
+    μb  = sum(b[mask]) / count(mask)
+    da  = a[mask] .- μa
+    db  = b[mask] .- μb
+    corr = dot(da, db) / (norm(da) * norm(db))
+    @test corr > 0.98
+end
+
+@testset "similarity alignment (scale=true) on synthetic images" begin
+    using Astroalign: align_frame
+    using PSFModels: gaussian
+    using CoordinateTransformations: AffineMap
+    using LinearAlgebra: I, norm
+    using Random: MersenneTwister
+
+    rng = MersenneTwister(5678)
+    img_size  = (500, 500)
+    fwhm      = 4.0
+    θ         = deg2rad(15)
+    scale_fac = 0.9                    # slight zoom-out in (row, col) space
+    c_θ, s_θ  = cos(θ), sin(θ)
+    M_fwd     = scale_fac * [c_θ -s_θ; s_θ c_θ]
+    center_rc = [250.0, 250.0]
+    δ_rc      = [8.0, -5.0]
+    t_fwd     = center_rc - M_fwd * center_rc + δ_rc
+    T_fwd     = AffineMap(M_fwd, t_fwd)
+
+    nstars = 18
+    stars_to_rc = [(rand(rng) * 200 + 150, rand(rng) * 200 + 150, rand(rng) * 0.5 + 0.5)
+                   for _ in 1:nstars]
+    stars_from_rc = map(stars_to_rc) do (r, c, amp)
+        pf = T_fwd([r, c])
+        (pf[1], pf[2], amp)
+    end
+
+    @test all(stars_from_rc) do (r, c, _)
+        1 ≤ round(Int, r) ≤ 500 && 1 ≤ round(Int, c) ≤ 500
+    end
+
+    img_to   = render_stars(stars_to_rc,   img_size, fwhm)
+    img_from = render_stars(stars_from_rc, img_size, fwhm)
+
+    img_aligned, params = align_frame(img_to, img_from;
+        scale            = true,
+        min_fwhm         = (0.5, 0.5),
+        N_max            = nstars,
+        ransac_threshold = 2.0,
+    )
+
+    @test params.tfm.linear ≈ M_fwd  atol=0.02
+    @test params.tfm.translation ≈ t_fwd  atol=1.0
+    @test length(params.inlier_idxs) ≥ nstars
+end
+
+@testset "RANSAC: two sub-images from a 2000 × 2000 master field" begin
+    # Two 512 × 512 sub-images are extracted from a large synthetic field via
+    # ImageTransformations.warp with known backward transforms.  align_frame
+    # must recover the relative rotation to better than ≈1° and produce a
+    # strongly-correlated aligned image.
+    #
+    # Geometry:
+    #   img_to  – axis-aligned crop covering master rows/cols [745:1256]
+    #   img_from – same *centre* (master 1000.5, 1000.5), rotated 22° CCW
+    #
+    # All 50 stars are place in master [820:1180, 820:1180] so they lie
+    # inside both sub-images regardless of the 22° rotation.
+    using Astroalign: align_frame
+    using PSFModels: gaussian
+    using CoordinateTransformations: AffineMap, LinearMap, Translation
+    using ImageTransformations: warp
+    using StaticArrays: SVector
+    using LinearAlgebra: norm, dot
+    using Random: MersenneTwister
+
+    function render_master(star_r, star_c, amps, sz, fwhm)
+        img = zeros(Float64, sz)
+        fwhm_int = ceil(Int, 3.0 * fwhm)
+        for (r, c, amp) in zip(star_r, star_c, amps)
+            r0, c0 = round(Int, r), round(Int, c)
+            for ir in max(1, r0 - fwhm_int):min(sz[1], r0 + fwhm_int),
+                    ic in max(1, c0 - fwhm_int):min(sz[2], c0 + fwhm_int)
+                img[ir, ic] += gaussian(Float64(ir), Float64(ic);
+                    x = Float64(r), y = Float64(c),
+                    fwhm = Float64(fwhm), amp = Float64(amp))
+            end
+        end
+        return img
+    end
+
+    rng = MersenneTwister(9999)
+
+    master_size = (2000, 2000)
+    fwhm = 5.0
+    nstars = 50
+
+    # Stars concentrated in [820:1180, 820:1180] – entirely within img_to AND
+    # within 256*cos(11°) ≈ 251 pixels of master centre, so within img_from.
+    star_r = rand(rng, 820:1180, nstars)
+    star_c = rand(rng, 820:1180, nstars)
+    star_a = rand(rng, nstars) .* 0.5 .+ 0.5
+
+    master = render_master(star_r, star_c, star_a, master_size, fwhm)
+
+    # img_to: axis-aligned crop, master offset (744, 744)
+    off1      = SVector(744.0, 744.0)
+    tfm1_back = Translation(off1)
+    img_to    = warp(master, tfm1_back, (1:512, 1:512))
+
+    # img_from: same master centre (1000.5, 1000.5), rotated 22° CCW
+    θ          = 22.0 * π / 180
+    c_θ, s_θ   = cos(θ), sin(θ)
+    R_rot      = [c_θ -s_θ; s_θ c_θ]           # rotation in (row, col) space
+    sub_ctr    = SVector(256.5, 256.5)
+    master_ctr = SVector(1000.5, 1000.5)
+    tfm2_back  = Translation(master_ctr) ∘ LinearMap(R_rot) ∘ Translation(-sub_ctr)
+    img_from   = warp(master, tfm2_back, (1:512, 1:512))
+
+    img_aligned, params = align_frame(img_to, img_from;
+        scale            = false,
+        min_fwhm         = (1.0, 1.0),
+        N_max            = 20,
+        ransac_threshold = 5.0,
+        k_nearest        = 8,
+    )
+
+    # params.tfm maps img_to → img_from in (row, col) space.
+    # tfm = inv(tfm2_back) ∘ tfm1_back → linear part ≈ R_rot' = R(-22°)
+    @test params.tfm.linear ≈ R_rot'  atol=0.02
+
+    @test length(params.inlier_idxs) ≥ 6
+
+    a = vec(img_aligned)
+    b = vec(Float64.(img_to))
+    mask = .!(isnan.(a) .| iszero.(a) .| iszero.(b))
+    @test count(mask) > 0
+    a_m, b_m = a[mask], b[mask]
+    μa, μb   = sum(a_m) / length(a_m), sum(b_m) / length(b_m)
+    da, db   = a_m .- μa, b_m .- μb
+    corr     = dot(da, db) / (norm(da) * norm(db))
+    @test corr > 0.95
+end
+


### PR DESCRIPTION
Closes #3. The main updates are in `src/register.jl` and `src/warp.jl`, most of which I hope should be relatively straightforward. 

Merging this, we should be able to remove `find_nearest` as I do not believe that is used any longer (it is used in the current `docs/notebook.jl` which I did not want to remove yet so I didn't remove the method from the source code).

I took a shot at vibe coding new tests with randomly generated data in `test/test-ransac.jl` and a pluto notebook `docs/ransac.md` which is like the current `docs/notebook.jl`. I manually went through `test-ransac.jl` and it looks okay -- there's some duplication we should try to minimize, some weird style stuff, etc. but I think the bones are decent. It might be nicer to test on real data though. I'm not a pluto user so IDK about the notebook, would appreciate if you could check that @icweaver. 

Happy to remove either of these (or move them to other PRs). I'm not really attached to either of these additions, except I do think that we should establish a better set of test data, synthetic or real, to confirm the performance of the implementation (it does not have to look like `test/test-ransac.jl` though).

