### PR TITLE
docs: update BackgroundMeshes.jl links

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ CairoMakie.activate!(type = "png", px_per_unit = 2)
 links = InterLinks(
     "Photometry" => "https://juliaastro.org/Photometry/stable/",
     "PSFModels" => "https://juliaastro.org/PSFModels/stable/",
+    "BackgroundMeshes" => "https://juliaastro.org/BackgroundMeshes/stable/",
 )
 
 makedocs(

--- a/src/findpeaks.jl
+++ b/src/findpeaks.jl
@@ -1,7 +1,7 @@
 """
     _get_sources(img; box_size = nothing, nsigma = 1, N_max = 10)
 
-Extract candidate sources in `img` according to [`Photometry.Detection.extract_sources`](@extref). By default, `img` is first sigma clipped and then background subtracted before the candidate sources are extracted. `box_size` is passed to [`Photometry.Background.estimate_background`](@extref), and `nsigma` is passed to [`Photometry.Detection.extract_sources`](@extref). See the [Photometry.jl](@extref) documentation for more.
+Extract candidate sources in `img` according to [`Photometry.Detection.extract_sources`](@extref). By default, `img` is first sigma clipped and then background subtracted before the candidate sources are extracted. `box_size` is passed to [`BackgroundMeshes.estimate_background`](@extref), and `nsigma` is passed to [`Photometry.Detection.extract_sources`](@extref). See the [Photometry.jl](@extref) documentation for more.
 
 TODO: Pass more options to clipping, background estimating, and extraction methods in [Photometry.jl](@extref).
 """


### PR DESCRIPTION
Photometry.jl v0.9.7 release includes BackgroundMeshes.jl split-out https://github.com/JuliaAstro/Photometry.jl/pull/95. This PR updates links accordingly.