### PR TITLE
feat: support coords, `find_transform`, and `apply_transform`

### DIFF
--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -171,7 +171,7 @@ opts_ransac = (; scale = true, ransac_threshold = 3.0);
 opts_refinement = (; final_iters = 3, opts_ransac...)
 
 # Align
-arr_from_aligned, params_aligned = align_frame(img_from, img_to; opts_phot..., opts_refinement...);
+arr_from_aligned = align_frame(img_from, img_to; opts_phot..., opts_refinement...);
 
 # Visualize
 plot_pair(arr_from_aligned, img_to; titles = ["img_from (aligned)", "img_to"])
@@ -181,11 +181,14 @@ That's it! See the next section for a brief analysis on how well we did.
 
 ## Recovered transformation
 
-The transformation object `tfm` returned by [`align_frame`](@ref) defines the mapping `img_from => img_to`:
+We can investigate the underlying transformation process by calling [`find_transform`](@ref):
 
 ```@example walkthrough
-tfm_aligned = params_aligned.tfm
+tfm_aligned, params_aligned = find_transform(img_from, img_to; opts_phot..., opts_refinement...);
 ```
+
+!!! tip
+    This can be used in conjunction with [`apply_transform`](@ref) to apply the transformation found. This is what [`align_frame`](@ref) calls under the hood.
 
 Decomposing it into scale (`S`), rotation (`R`), and translation (`T`) components then gives:
 
@@ -225,9 +228,6 @@ println("RANSAC inliers: $n_inliers / $n_total ($(round(100*n_inliers/n_total; d
 ```
 
 The rest of this document will walk through how this is accomplished behind the scenes, and the different options that we can pass to [`align_frame`](@ref).
-
-!!! tip
-    Use [`find_transform`](@ref) to just compute the transformation without applying it to the image. This is useful for checking parameters beforehand or storing them for future analysis.
 
 ## Step 1: Identify control points
 
@@ -302,7 +302,7 @@ This is done internally in [`align_frame`](@ref), but the invariants ``\mathscr 
 C_to, ℳ_to = Astroalign._triangle_invariants(phot_to)
 
 # This can also be accessed through the named tuple
-# returned by `Astroalign.align_frame`.
+# returned by `find_transform`.
 (; C_from, ℳ_from) = params_aligned
 ```
 

--- a/src/Astroalign.jl
+++ b/src/Astroalign.jl
@@ -16,7 +16,7 @@ using Photometry:
     PeakMesh
 using TypedTables: Table
 
-export align_frame, find_transform
+export align_frame, find_transform, apply_transform
 
 include("findpeaks.jl")
 include("register.jl")

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -152,7 +152,7 @@ function find_transform(img_from, img_to;
     # Note that _triangle_distfn expects a from => to transform.
     tfm, inlier_idxs, point_map = _refine_transform(fwd_tfm_initial, inlier_idxs_initial, correspondences; final_iters, scale, ransac_threshold)
 
-    return tfm, (; point_map, correspondences, inlier_idxs, C_from, ℳ_from, C_to, ℳ_to, phot_from_params, phot_to_params)
+    return tfm, (; point_map, correspondences, inlier_idxs, C_from, ℳ_from, C_to, ℳ_to, phot_from, phot_to, phot_from_params, phot_to_params)
 end
 
 get_phot(img::AbstractMatrix; kwargs...) = _photometry(img; kwargs...)

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -31,13 +31,20 @@ Alignment algorithm:
 """
 function align_frame(img_from, img_to; warp_function = warp, kwargs...)
     # Steps 1 - 5
-    tfm, tfm_params = find_transform(img_from, img_to; kwargs...)
+    tfm, _ = find_transform(img_from, img_to; kwargs...)
 
     # Step 6: Apply the transform (from => to)
-    warp_img = warp_function(img_from, inv(tfm), axes(img_to))
+    warp_img = apply_transform(tfm, img_from, img_to; warp_function = warp)
 
-    return warp_img, (; tfm, tfm_params...)
+    return warp_img
 end
+
+"""
+    apply_transform(tfm, img_from, img_to; warp_function = warp)
+
+Apply transformation `tfm` to `img_from`, keeping axes consistent with `img_to`. `tfm` is typically supplied by [`find_transform`](@ref), which is automatically computed internally by [`align_frame`](@ref).
+"""
+apply_transform(tfm, img_from, img_to; warp_function = warp) = warp_function(img_from, inv(tfm), axes(img_to))
 
 """
     _ransac(correspondences; scale, ransac_threshold)
@@ -92,6 +99,8 @@ end
 Compute the transformation needed to align `img_from` onto `img_to`, assuming both images are related via a rigid
 (or similarity, when `scale = true`) transformation. Automatically called by [`align_frame`](@ref).
 
+If `img_from` or `img_to` is instead passed as a list of (x, y) coordinates for the given sources, then the photometry step will be skipped for that image.
+
 # Parameters
 
 - `box_size`: The size of the grid cells (in pixels) used to extract candidate point sources to use for alignment. Defaults to (3, 3) pixels. See [Photometry.jl > Source Detection Algorithms](@extref Photometry Source-Detection-Algorithms) for more.
@@ -118,8 +127,8 @@ function find_transform(img_from, img_to;
     final_iters = 3,
 )
     # Step 1: Identify control points
-    phot_from, phot_from_params = _photometry(img_from; box_size, ap_radius, f, min_fwhm, nsigma, N_max, use_fitpos)
-    phot_to, phot_to_params = _photometry(img_to; box_size, ap_radius, f, min_fwhm, nsigma, N_max, use_fitpos)
+    phot_from, phot_from_params = get_phot(img_from; box_size, ap_radius, f, min_fwhm, nsigma, N_max, use_fitpos)
+    phot_to, phot_to_params = get_phot(img_to; box_size, ap_radius, f, min_fwhm, nsigma, N_max, use_fitpos)
 
     # Step 2: Calculate invariants
     C_from, ℳ_from = _triangle_invariants(phot_from)
@@ -145,3 +154,6 @@ function find_transform(img_from, img_to;
 
     return tfm, (; point_map, correspondences, inlier_idxs, C_from, ℳ_from, C_to, ℳ_to, phot_from_params, phot_to_params)
 end
+
+get_phot(img::AbstractMatrix; kwargs...) = _photometry(img; kwargs...)
+get_phot(coords::AbstractVector; kwargs...) = Table(; xcenter = first.(coords), ycenter = last.(coords)), ()

--- a/test/test-functions.jl
+++ b/test/test-functions.jl
@@ -108,6 +108,8 @@ end
         :ℳ_from,
         :C_to,
         :ℳ_to,
+        :phot_from,
+        :phot_to,
         :phot_from_params,
         :phot_to_params,
     )

--- a/test/test-functions.jl
+++ b/test/test-functions.jl
@@ -33,16 +33,26 @@ end
     img_to = Data.img_to
     img_from = Data.img_from
 
-    img_aligned, params = align_frame(img_from, img_to; box_size = 1, ap_radius = 1, min_fwhm = (0.1, 0.1))
+    img_aligned = align_frame(img_from, img_to; box_size = 1, ap_radius = 1, min_fwhm = (0.1, 0.1))
 
     @test img_aligned ≈ img_to
+end
+
+@testset "find_transform" begin
+    using Astroalign: find_transform
+
+    img_to = Data.img_to
+    img_from = [(9, 9), (5, 6), (9, 6)]
+
+    tfm, params = find_transform(img_from, img_to; box_size = 1, ap_radius = 1, min_fwhm = (0.1, 0.1))
+
     @test params.point_map == [
         [9.0, 9.0] => [6.0, 9.0],
         [5.0, 6.0] => [2.0, 6.0],
         [9.0, 6.0] => [6.0, 6.0]
     ]
-    @test params.tfm.linear ≈ [1 0; 0 1]
-    @test params.tfm.translation ≈ [-3.0, 0.0]
+    @test tfm.linear ≈ [1 0; 0 1]
+    @test tfm.translation ≈ [-3.0, 0.0]
 end
 
 @testset "photometry" begin
@@ -76,21 +86,21 @@ end
 end
 
 @testset "api"  begin
-    import Astroalign
+    using Astroalign: PSF, find_transform, apply_transform
 
     img_to = Data.img_to
     img_from = Data.img_from
 
-    img_aligned, p = Astroalign.align_frame(img_to, img_from;
+    tfm, p = find_transform(img_to, img_from;
         box_size = 1,
         ap_radius = 1,
         min_fwhm = 0.1,
-        f = Astroalign.PSF(params = (x = 6, y = 6, fwhm = 0.2))
+        f = PSF(params = (x = 6, y = 6, fwhm = 0.2))
     )
+    img_aligned = apply_transform(tfm, img_from, img_to)
 
     @test img_aligned isa AbstractMatrix
     @test propertynames(p) == (
-        :tfm,
         :point_map,
         :correspondences,
         :inlier_idxs,

--- a/test/test-ransac.jl
+++ b/test/test-ransac.jl
@@ -78,10 +78,10 @@ end
     # All coordinates are in Astroalign's native (xcenter=row, ycenter=col) convention.
     # Stars are rendered with PSFModels.gaussian(row_eval, col_eval; x=row_star, y=col_star).
     # The forward transform T_fwd maps img_to star (row, col) positions to img_from positions.
-    # align_frame recovers this as params.tfm (backward: img_to → img_from), so:
-    #   params.tfm.linear     ≈ R_fwd
-    #   params.tfm.translation ≈ t_fwd
-    using Astroalign: align_frame
+    # find_transform recovers this as tfm (backward: img_to → img_from), so:
+    #   tfm.linear     ≈ R_fwd
+    #   tfm.translation ≈ t_fwd
+    using Astroalign: find_transform, apply_transform
     using PSFModels: gaussian
     using CoordinateTransformations: AffineMap
     using LinearAlgebra: I, norm, dot
@@ -119,12 +119,13 @@ end
     img_to   = render_stars(stars_to_rc,   img_size, fwhm)
     img_from = render_stars(stars_from_rc, img_size, fwhm)
 
-    img_aligned, params = align_frame(img_from, img_to;
+    tfm, params = find_transform(img_from, img_to;
         scale            = false,
         min_fwhm         = (0.5, 0.5),
         N_max            = nstars,
         ransac_threshold = 2.0,
     )
+    img_aligned = apply_transform(tfm, img_from, img_to)
 
     # Test uniqueness of correspondences
     for i in axes(params.correspondences, 4)
@@ -141,8 +142,8 @@ end
     end
 
     # Recovered forward transform (img_from → img_to) should match T_fwd
-    @test params.tfm.linear ≈ R_fwd  atol=0.01
-    @test params.tfm.translation ≈ t_fwd  atol=1.0
+    @test tfm.linear ≈ R_fwd  atol=0.01
+    @test tfm.translation ≈ t_fwd  atol=1.0
 
     # RANSAC should utilise most of the stars as inliers
     @test length(params.inlier_idxs) ≥ nstars
@@ -160,7 +161,7 @@ end
 end
 
 @testset "similarity alignment (scale=true) on synthetic images" begin
-    using Astroalign: align_frame
+    using Astroalign: find_transform, apply_transform
     using PSFModels: gaussian
     using CoordinateTransformations: AffineMap
     using LinearAlgebra: I, norm
@@ -193,15 +194,16 @@ end
     img_to   = render_stars(stars_to_rc,   img_size, fwhm)
     img_from = render_stars(stars_from_rc, img_size, fwhm)
 
-    img_aligned, params = align_frame(img_from, img_to;
+    tfm, params = find_transform(img_from, img_to;
         scale            = true,
         min_fwhm         = (0.5, 0.5),
         N_max            = nstars,
         ransac_threshold = 2.0,
     )
+    img_aligned = apply_transform(tfm, img_from, img_to)
 
-    @test params.tfm.linear ≈ M_fwd  atol=0.02
-    @test params.tfm.translation ≈ t_fwd  atol=1.0
+    @test tfm.linear ≈ M_fwd  atol=0.02
+    @test tfm.translation ≈ t_fwd  atol=1.0
     @test length(params.inlier_idxs) ≥ nstars
 end
 
@@ -217,7 +219,7 @@ end
     #
     # All 50 stars are place in master [820:1180, 820:1180] so they lie
     # inside both sub-images regardless of the 22° rotation.
-    using Astroalign: align_frame
+    using Astroalign: find_transform, apply_transform
     using PSFModels: gaussian
     using CoordinateTransformations: AffineMap, LinearMap, Translation
     using ImageTransformations: warp
@@ -268,16 +270,17 @@ end
     tfm2_back  = Translation(master_ctr) ∘ LinearMap(R_rot) ∘ Translation(-sub_ctr)
     img_from   = warp(master, tfm2_back, (1:512, 1:512))
 
-    img_aligned, params = align_frame(img_from, img_to;
+    tfm, params = find_transform(img_from, img_to;
         scale            = false,
         min_fwhm         = (1.0, 1.0),
         N_max            = 20,
         ransac_threshold = 5.0,
     )
+    img_aligned = apply_transform(tfm, img_from, img_to)
 
     # params.tfm maps img_from → img_to in (row, col) space.
     # tfm = inv(tfm2_back) ∘ tfm1_back → linear part ≈ R_rot' = R(-22°)
-    @test params.tfm.linear ≈ R_rot  atol=0.02
+    @test tfm.linear ≈ R_rot  atol=0.02
 
     @test length(params.inlier_idxs) ≥ 6
 


### PR DESCRIPTION
## Features

- Pass list of (x, y) coordinates in place of `img_from`/`img_to` to bypass photometry step
- Split `align_frame` into a `find_transform` and `apply_transform` step

## Changes to existing behavior

Only return debug data in `find_transform` step now instead of in `align_frame`. Also includes additional photometry info like psf model params.

Documentation preview: https://juliaastro.github.io/Astroalign.jl/previews/PR48/

Closes: #42, #44