### PR TITLE
refactor: change return format for `_triangle_distfn`

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -203,5 +203,5 @@ function _triangle_distfn(M_candidates, x, t)
         end
     end
 
-    return best_inliers, best_M
+    return (inliers = best_inliers, model = best_M)
 end


### PR DESCRIPTION
This fix is needed to support the new expected return API in ConsensusFitting.jl (see https://github.com/JuliaAstro/ConsensusFitting.jl/pull/10). 