### PR TITLE
style: `align_frame` --> `align_frames`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ The following will align `img_from` onto `img_to`:
 ```julia
 using Astroalign
 
-img_aligned, params_aligned = align_frame(img_from, img_to)
+img_aligned, params_aligned = align_frames(img_from, img_to)
 ```
 
 !!! info

--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -154,7 +154,7 @@ end
 
 ## Usage
 
-We now use the exported [`align_frame`](@ref) function to align our image:
+We now use the exported [`align_frames`](@ref) function to align our image:
 
 ```@example walkthrough
 # Available options
@@ -171,7 +171,7 @@ opts_ransac = (; scale = true, ransac_threshold = 3.0);
 opts_refinement = (; final_iters = 3, opts_ransac...)
 
 # Align
-arr_from_aligned = align_frame(img_from, img_to; opts_phot..., opts_refinement...);
+arr_from_aligned = align_frames(img_from, img_to; opts_phot..., opts_refinement...);
 
 # Visualize
 plot_pair(arr_from_aligned, img_to; titles = ["img_from (aligned)", "img_to"])
@@ -188,7 +188,7 @@ tfm_aligned, params_aligned = find_transform(img_from, img_to; opts_phot..., opt
 ```
 
 !!! tip
-    This can be used in conjunction with [`apply_transform`](@ref) to apply the transformation found. This is what [`align_frame`](@ref) calls under the hood.
+    This can be used in conjunction with [`apply_transform`](@ref) to apply the transformation found. This is what [`align_frames`](@ref) calls under the hood.
 
 Decomposing it into scale (`S`), rotation (`R`), and translation (`T`) components then gives:
 
@@ -227,7 +227,7 @@ n_total   = size(params_aligned.correspondences, 4)
 println("RANSAC inliers: $n_inliers / $n_total ($(round(100*n_inliers/n_total; digits = 1))%)")
 ```
 
-The rest of this document will walk through how this is accomplished behind the scenes, and the different options that we can pass to [`align_frame`](@ref).
+The rest of this document will walk through how this is accomplished behind the scenes, and the different options that we can pass to [`align_frames`](@ref).
 
 ## Step 1: Identify control points
 
@@ -296,7 +296,7 @@ With our sources identified, we now turn to the next step in the alignment algor
 
 ## Step 2: Calculate invariants
 
-This is done internally in [`align_frame`](@ref), but the invariants ``\mathscr M_i`` can also be exposed with [`Astroalign._triangle_invariants`](@ref).
+This is done internally in [`align_frames`](@ref), but the invariants ``\mathscr M_i`` can also be exposed with [`Astroalign._triangle_invariants`](@ref).
 
 ```@example walkthrough
 C_to, ℳ_to = Astroalign._triangle_invariants(phot_to)

--- a/src/Astroalign.jl
+++ b/src/Astroalign.jl
@@ -16,7 +16,7 @@ using Photometry:
     PeakMesh
 using TypedTables: Table
 
-export align_frame, find_transform, apply_transform
+export align_frames, find_transform, apply_transform
 
 include("findpeaks.jl")
 include("register.jl")

--- a/src/findpeaks.jl
+++ b/src/findpeaks.jl
@@ -65,9 +65,9 @@ end
 """
     _photometry(img; box_size, ap_radius, min_fwhm, nsigma, f, N_max, use_fitpos)
 
-Internal function used by [`align_frame`](@ref). Calls to [`Photometry.Aperture.photometry`](@extref) with reasonable defaults.
+Internal function used by [`align_frames`](@ref). Calls to [`Photometry.Aperture.photometry`](@extref) with reasonable defaults.
 
-See [`align_frame`](@ref) for keyword arguments.
+See [`align_frames`](@ref) for keyword arguments.
 """
 function _photometry(img; box_size, ap_radius, min_fwhm, nsigma, f, N_max, use_fitpos)
     # Sources, background subtracted image, background

--- a/src/warp.jl
+++ b/src/warp.jl
@@ -1,5 +1,5 @@
 """
-    function align_frame(img_from, img_to; [warp_function], kwargs...)
+    function align_frames(img_from, img_to; [warp_function], kwargs...)
 
 Align `img_from` onto `img_to`.
 
@@ -29,7 +29,7 @@ Alignment algorithm:
    applied to all vertex pairs from all inlier triangle matches.
 6. Finally, warp `img_from` to the coordinates of `img_to`.
 """
-function align_frame(img_from, img_to; warp_function = warp, kwargs...)
+function align_frames(img_from, img_to; warp_function = warp, kwargs...)
     # Steps 1 - 5
     tfm, _ = find_transform(img_from, img_to; kwargs...)
 
@@ -42,7 +42,7 @@ end
 """
     apply_transform(tfm, img_from, img_to; warp_function = warp)
 
-Apply transformation `tfm` to `img_from`, keeping axes consistent with `img_to`. `tfm` is typically supplied by [`find_transform`](@ref), which is automatically computed internally by [`align_frame`](@ref).
+Apply transformation `tfm` to `img_from`, keeping axes consistent with `img_to`. `tfm` is typically supplied by [`find_transform`](@ref), which is automatically computed internally by [`align_frames`](@ref).
 """
 apply_transform(tfm, img_from, img_to; warp_function = warp) = warp_function(img_from, inv(tfm), axes(img_to))
 
@@ -97,7 +97,7 @@ end
     )
 
 Compute the transformation needed to align `img_from` onto `img_to`, assuming both images are related via a rigid
-(or similarity, when `scale = true`) transformation. Automatically called by [`align_frame`](@ref).
+(or similarity, when `scale = true`) transformation. Automatically called by [`align_frames`](@ref).
 
 If `img_from` or `img_to` is instead passed as a list of (x, y) coordinates for the given sources, then the photometry step will be skipped for that image.
 
@@ -138,7 +138,7 @@ function find_transform(img_from, img_to;
     correspondences = _build_correspondences(C_from, ℳ_from, C_to, ℳ_to)
 
     size(correspondences, 4) < 1 &&
-        error("align_frame: not enough candidate correspondences ($(size(correspondences, 4))); " *
+        error("align_frames: not enough candidate correspondences ($(size(correspondences, 4))); " *
               "ensure both images contain at least 3 detectable point sources")
 
     # Step 4: RANSAC on triangle matches to find the largest set of mutually consistent correspondences (inliers)

--- a/test/test-functions.jl
+++ b/test/test-functions.jl
@@ -27,13 +27,13 @@ end
     @test errs == zero(subt)
 end
 
-@testset "align_frame" begin
-    using Astroalign: align_frame
+@testset "align_frames" begin
+    using Astroalign: align_frames
 
     img_to = Data.img_to
     img_from = Data.img_from
 
-    img_aligned = align_frame(img_from, img_to; box_size = 1, ap_radius = 1, min_fwhm = (0.1, 0.1))
+    img_aligned = align_frames(img_from, img_to; box_size = 1, ap_radius = 1, min_fwhm = (0.1, 0.1))
 
     @test img_aligned ≈ img_to
 end

--- a/test/test-ransac.jl
+++ b/test/test-ransac.jl
@@ -209,7 +209,7 @@ end
 
 @testset "RANSAC: two sub-images from a 2000 × 2000 master field" begin
     # Two 512 × 512 sub-images are extracted from a large synthetic field via
-    # ImageTransformations.warp with known backward transforms.  align_frame
+    # ImageTransformations.warp with known backward transforms.  align_frames
     # must recover the relative rotation to better than ≈1° and produce a
     # strongly-correlated aligned image.
     #


### PR DESCRIPTION
In preparation for a generic `align_frames` function that can accept one or multiple images + photometry tables